### PR TITLE
Updated elgohr/Github-Release-Action to a supported version (v4)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
       with:
         github_token: ${{ secrets.token }}
     - name: 'create release'
-      uses: elgohr/Github-Release-Action@master
+      uses: elgohr/Github-Release-Action@v4
       env:
         GITHUB_TOKEN: ${{ secrets.token }}
       with:


### PR DESCRIPTION
elgohr/Github-Release-Action@master is not supported anymore